### PR TITLE
removing experimental friends reference path

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -10,11 +10,6 @@ module.exports = function pluginInit (mongoose) {
 
         // debug('schema', schema)
         
-        // add an array of refs to the user's friends
-        schema.add({
-            friends: [ { type: mongoose.Schema.Types.ObjectId, ref: pluginOptions.personModelName }]
-        });
-
         debug('pluginOptions', pluginOptions);
 
         Friendship = require('./friendship')(mongoose, pluginOptions);


### PR DESCRIPTION
Adding the `friends` reference path is an experimental feature targeted for v4.x that slipped into v3.x @ 26344898e5e3a37896d2a847ae567c40b791554d.  

This PR resolves that issue for v3.x.